### PR TITLE
Opt out of cloudant auto-config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,7 @@
 								<JBP_CONFIG_LIBERTY>app_archive: {features: [websocket-1.1,
 									servlet-3.1]}</JBP_CONFIG_LIBERTY>
 							</env>
+							<services_autoconfig_excludes>cloudantNoSQLDB=all</services_autoconfig_excludes>
 							<services>
 								<service>
 									<name>${APPNAME}-cloudant</name>


### PR DESCRIPTION
This fixes errors like 

```
2015-07-15T16:41:14.92-0400 [App/0]      ERR [err] SLF4J: Class path contains multiple SLF4J bindings.
2015-07-15T16:41:14.92-0400 [App/0]      ERR [err] SLF4J: Found binding in [wsjar:file:/home/vcap/app/wlp/usr/servers/defaultServer/apps/myapp.war/WEB-INF/lib/slf4j-simple-1.7.7.jar!/org/slf4j/impl/StaticLoggerBinder.class]
2015-07-15T16:41:14.92-0400 [App/0]      ERR [err] SLF4J: Found binding in [wsjar:file:/home/vcap/app/wlp/usr/servers/defaultServer/lib/slf4j-jdk14-1.6.6.jar!/org/slf4j/impl/StaticLoggerBinder.class]
2015-07-15T16:41:14.92-0400 [App/0]      ERR [err] SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
2015-07-15T16:41:14.96-0400 [App/0]      ERR [err] SLF4J: Actual binding is of type [org.slf4j.impl.SimpleLoggerFactory]
```
